### PR TITLE
support for the BMP280 (same as BME280 w/o humidity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # signalk-raspberry-pi-bme280
-BME-280 temperature, humidity, and pressure sensor information for SignalK. This plugin can be downloaded via the SignalK application.
+BME-280/BMP-280 temperature, pressure and humidity (BME only) sensor information for SignalK. This plugin can be downloaded via the SignalK application.
 
 ## Getting Started
-You will need a raspberry pi with SignalK installed along with a BME280 sensor.
+You will need a raspberry pi with SignalK installed along with a BME280 or BMP280 sensor.
 
 ### The BME280 sensor
 Personally I am using the sensor found at the following link on Amazon. However there are many manufacturers to pick from. I liked the form factor and cable harness of this one.

--- a/index.js
+++ b/index.js
@@ -44,6 +44,25 @@ module.exports = function (app) {
   plugin.start = function (options) {
     
     function createDeltaMessage (temperature, humidity, pressure) {
+      var values = [
+        {
+          'path': 'environment.' + options.path + '.temperature',
+          'value': temperature
+        }, {
+          'path': 'environment.' + options.path + '.pressure',
+          'value': pressure
+        }
+      ];
+
+      // BMP280 will read 0 as it has no humidity sensor
+      if (humidity > 0) {
+        values.push(
+          {
+            'path': 'environment.' + options.path + '.humidity',
+            'value': humidity
+	  });
+      }
+
       return {
         'context': 'vessels.' + app.selfId,
         'updates': [
@@ -52,18 +71,7 @@ module.exports = function (app) {
               'label': plugin.id
             },
             'timestamp': (new Date()).toISOString(),
-            'values': [
-              {
-                'path': 'environment.' + options.path + '.temperature',
-                'value': temperature
-              }, {
-                'path': 'environment.' + options.path + '.humidity',
-                'value': humidity
-              }, {
-                'path': 'environment.' + options.path + '.pressure',
-                'value': pressure
-              }
-            ]
+            'values': values
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "signalk-raspberry-pi-bme280",
   "author": "Jeremy Carter",
-  "description": "SignalK node server plugin that reads data from bme280 temperature/humidity/barometer sensors on Raspberry-Pi",
+  "description": "SignalK node server plugin that reads data from bme280/bmp280 temperature/humidity/barometer sensors on Raspberry-Pi",
   "license": "MIT",
   "homepage": "https://github.com/jncarter123/signalk-raspberry-pi-bme280#readme",
   "version": "1.1.0",


### PR DESCRIPTION
hi! i am using a BerryIMUv2 board (https://ozzmaker.com/berryimu-quick-start-guide/) which has a BMP280 on it. This is apparently the same as the BME280 just w/o a humidity sensor. I modified your awesome signalk plugin to not report a humidity of 0 in the delta. Note I am not a Javascript person so excuse any ugliness, but tested on my RPi and seems to work =)

Not sure where the signalk description is, but would be cool to update that to include BME280/BMP280 as well so folks know it's compatible.

Thanks!