### PR TITLE
Add support for reading from multiple sensors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,32 +18,65 @@ module.exports = function (app) {
     type: 'object',
     properties: {
       rate: {
-        title: "Sample Rate (in seconds)",
+        title: "Sample Rate (in seconds) for all sensors",
         type: 'number',
         default: 60
       },
-      path: {
-        type: 'string',
-        title: 'SignalK Path',
-        description: 'This is used to build the path in Signal K. It will be appended to \'environment\'',
-        default: 'inside.salon'
-      },
-      i2c_bus: {
-        type: 'integer',
-        title: 'I2C bus number',
-        default: 1,
-      },
-      i2c_address: {
-        type: 'string',
-        title: 'I2C address',
-        default: '0x77',
-      },
+      sensors: {
+        type: 'array',
+        items: {
+          type: 'object',
+          minItems: 1,
+          properties: {
+            path: {
+              type: 'string',
+              title: 'SignalK Path',
+              description: 'This is used to build the path in Signal K. It will be appended to \'environment\'',
+              default: 'inside.salon'
+            },
+            i2c_bus: {
+              type: 'integer',
+              title: 'I2C bus number',
+              default: 1,
+            },
+            i2c_address: {
+              type: 'string',
+              title: 'I2C address',
+              default: BME280.BME280_DEFAULT_I2C_ADDRESS(),
+            },
+          }
+        }
+      }
     }
   }
 
   plugin.start = function (options) {
-    
-    function createDeltaMessage (temperature, humidity, pressure) {
+    function createDeltaMessage (observations) {
+      const values_arr = []
+      for (const[index, data] of observations.entries()) {
+        //console.log(`Data: = ${JSON.stringify(data, null, 2)} Idx = ${JSON.stringify(index, null, 2)}`);
+        const temperature = data.measurements.temperature_C + 273.15;
+        const pressure = data.measurements.pressure_hPa * 100;
+        const humidity = data.measurements.humidity;
+        values_arr.push(
+          {
+            'path': 'environment.' + data.path + '.temperature',
+            'value': temperature
+          }
+        );
+        values_arr.push(
+          {
+            'path': 'environment.' + data.path + '.humidity',
+            'value': humidity
+          }
+        );
+        values_arr.push(
+          {
+            'path': 'environment.' + data.path + '.pressure',
+             'value': pressure
+           }
+        );
+      }; 
       return {
         'context': 'vessels.' + app.selfId,
         'updates': [
@@ -52,67 +85,71 @@ module.exports = function (app) {
               'label': plugin.id
             },
             'timestamp': (new Date()).toISOString(),
-            'values': [
-              {
-                'path': 'environment.' + options.path + '.temperature',
-                'value': temperature
-              }, {
-                'path': 'environment.' + options.path + '.humidity',
-                'value': humidity
-              }, {
-                'path': 'environment.' + options.path + '.pressure',
-                'value': pressure
-              }
-            ]
+            'values': values_arr
           }
         ]
       }
     }
 
-    // The BME280 constructor options are optional.
-    //
-    const bmeoptions = {
-      i2cBusNo   : options.i2c_bus || 1, // defaults to 1
-      i2cAddress : Number(options.i2c_address || '0x77'), // defaults to 0x77
-    };
-
-    const bme280 = new BME280(bmeoptions);
-
     // Read BME280 sensor data
     function readSensorData() {
-  	  bme280.readSensorData()
-          .then((data) => {
-        // temperature_C, pressure_hPa, and humidity are returned by default.
-        temperature = data.temperature_C + 273.15;
-        pressure = data.pressure_hPa * 100;
-        humidity = data.humidity;
+      const all_data = []
 
-        //console.log(`data = ${JSON.stringify(data, null, 2)}`);
-
-        // create message
-        var delta = createDeltaMessage(temperature, humidity, pressure)
-
-        // send temperature
+      const data_complete = new Promise((resolve, reject) => {
+        bme_sensors.forEach(function(value, index, array) {
+          value.bme.readSensorData()
+            .then((data) => {
+              //console.log(`sensor_data[${value.path}] = ${JSON.stringify(data, null, 2)}`);
+              all_data.push({path: value.path, measurements: data})
+              if (index === array.length -1) resolve();
+            })
+            .catch((err) => {
+              console.log(`BME280 read error: ${err}`);
+            });
+        });
+      });
+      data_complete.then(() => {
+        // create message from all sensor data.
+        const delta = createDeltaMessage(all_data)
+    
         app.handleMessage(plugin.id, delta)
-
-      })
-      .catch((err) => {
-        console.log(`BME280 read error: ${err}`);
       });
     }
 
-    bme280.init()
-        .then(() => {
-      console.log('BME280 initialization succeeded');
-      readSensorData();
-    })
-    .catch((err) => console.error(`BME280 initialization failed: ${err} `));
+    // The BME280 constructor options are optional.
+    const sensors = options.sensors
+    const bme_sensors = [];
+    for (const[index, value] of sensors.entries()) {
+      //console.log(`Sensor settings[${index}] = ${JSON.stringify(value, null, 2)}`)
+      const bmeoptions = {
+        i2cBusNo   : value.i2c_bus || 1, // defaults to 1
+        i2cAddress : Number(value.i2c_address || BME280.BME280_DEFAULT_I2C_ADDRESS()), // defaults to 0x77
+      };
+      const bme280 = new BME280(bmeoptions);
+      bme_sensors.push({path: value.path, bme: bme280});
+    };
+    //TODO: Is it worth validating the input to ensure uniqueness?
 
-    timer = setInterval(readSensorData, options.rate * 1000);
+    const init_complete = new Promise((resolve, reject) => {
+      bme_sensors.forEach(function(value, index, array) {
+        value.bme.init().then(() => {
+          console.log(`BME280[${value.path}] initialization succeeded`);
+          if (index === array.length -1) resolve();
+        })
+        .catch((err) => {
+          console.error(`BME280[${value.path}] initialization failed: ${err} `);
+        });
+      }); 
+    });
+    init_complete.then(() => {
+      readSensorData()
+
+      timer = setInterval(readSensorData, options.rate * 1000);
+    });
   }
 
   plugin.stop = function () {
-    if(timer){
+    if (timer){
       clearInterval(timer);
       timeout = null;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-raspberry-pi-bme280",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "SignalK node server plugin that reads data from bme280 temperature/humidity/barometer sensors on Raspberry-Pi",
   "license": "MIT",
   "homepage": "https://github.com/jncarter123/signalk-raspberry-pi-bme280#readme",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "keywords": [
     "signalk-node-server-plugin"
@@ -18,5 +18,9 @@
   },
   "dependencies": {
     "bme280-sensor": "0.1.6"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   }
 }


### PR DESCRIPTION
Add support for reading from multiple sensors using an array of options.  This allows the use of the bme280 with the addr pin grounded to make it 0x76 (tested), allowing 2 devices on the same i2c bus (tested), and would multiple sensors on different busses (not tested, no available hardware).

Settings:
![bmeSettings](https://user-images.githubusercontent.com/10092248/102301108-0d952380-3f0b-11eb-9091-15b715ed3e02.PNG)

Delta message outcome:
![bme280](https://user-images.githubusercontent.com/10092248/102301114-0ff77d80-3f0b-11eb-904e-e8fa11d935e0.PNG)

