### PR TITLE
update bme280-sensor to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "url": "https://github.com/jncarter123/signalk-raspberry-pi-bme280/issues"
   },
   "dependencies": {
-    "bme280-sensor": "0.1.6"
+    "bme280-sensor": "0.1.7"
   }
 }


### PR DESCRIPTION
Hi,
just updating bme280-sensor to 0.1.7 made it possible to install.
Thanks,
Daniel