### PR TITLE
Change humidity and dewpoint paths to standard names

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,12 +58,12 @@ module.exports = function (app) {
       if (humidity > 0) {
         values.push(
           {
-            'path': 'environment.' + options.path + '.humidity',
+            'path': 'environment.' + options.path + '.relativeHumidity',
             'value': humidity
           });
         values.push(
           {
-            'path': 'environment.' + options.path + '.dewPointTemperature',
+            'path': 'environment.' + options.path + '.dewPoint',
             'value': dewPoint
           });
       }


### PR DESCRIPTION
"dewPoint" and "relativHumidity" are the specified path names for these parameters.  when the correct path is used then the metadata (description and units) are automatically set correctly.
This fixes issue #10
I've tested this by using path mapper to change the path names and this makes the units and description metadata appear.
Sorry, I don't know enough to test the changes directly.